### PR TITLE
Add ostruct as an explicit dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 PATH
   remote: .
   specs:
-    timescaledb (0.3.0)
+    timescaledb (0.3.1)
       activerecord
       activesupport
+      ostruct
       pg (~> 1.2)
 
 GEM
@@ -32,6 +33,7 @@ GEM
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
     minitest (5.18.0)
+    ostruct (0.6.1)
     pg (1.5.8)
     pry (0.14.2)
       coderay (~> 1.1)

--- a/Gemfile.scenic.lock
+++ b/Gemfile.scenic.lock
@@ -1,9 +1,10 @@
 PATH
   remote: .
   specs:
-    timescaledb (0.2.8)
+    timescaledb (0.3.1)
       activerecord
       activesupport
+      ostruct
       pg (~> 1.2)
 
 GEM
@@ -56,7 +57,8 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    pg (1.5.6)
+    ostruct (0.6.1)
+    pg (1.5.9)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -116,4 +118,4 @@ DEPENDENCIES
   timescaledb!
 
 BUNDLED WITH
-   2.2.33
+   2.3.7

--- a/lib/timescaledb/connection.rb
+++ b/lib/timescaledb/connection.rb
@@ -1,4 +1,5 @@
 require 'singleton'
+require 'ostruct'
 
 module Timescaledb
   # Minimal connection setup for Timescaledb directly with the PG.

--- a/lib/timescaledb/hypertable.rb
+++ b/lib/timescaledb/hypertable.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module Timescaledb
   class Hypertable < ::Timescaledb::ApplicationRecord
     self.table_name = "timescaledb_information.hypertables"

--- a/lib/timescaledb/version.rb
+++ b/lib/timescaledb/version.rb
@@ -1,3 +1,3 @@
 module Timescaledb
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/spec/timescaledb/connection_spec.rb
+++ b/spec/timescaledb/connection_spec.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 RSpec.describe Timescaledb do
   describe '.establish_connection' do
     it 'returns a PG::Connection object' do

--- a/timescaledb.gemspec
+++ b/timescaledb.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pg", "~> 1.2"
   spec.add_dependency "activerecord"
   spec.add_dependency "activesupport"
+  spec.add_dependency "ostruct"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rspec-its"


### PR DESCRIPTION
This gem makes use of `OpenStruct` however this appears to be steadily being removed by default over time:
 - https://github.com/mileszs/wicked_pdf/issues/1116
 - https://github.com/ruby/ruby/pull/10428
 - https://github.com/rails/jbuilder/issues/561

Without OpenStruct on the system it causes the errors when running migrations:

```ruby
bin/rails aborted!
NameError: uninitialized constant Timescaledb::Connection::OpenStruct (NameError)

      query.map(&OpenStruct.method(:new))
                 ^^^^^^^^^^

Tasks: TOP => db:schema:dump
```

**Ideally** the implementation would be changed to switch OpenStruct with Struct, but this patches breakages in the meantime.