### PR TITLE
Use drop_table t, if_exists: true

### DIFF
--- a/examples/all_in_one/all_in_one.rb
+++ b/examples/all_in_one/all_in_one.rb
@@ -22,7 +22,7 @@ end
 ActiveRecord::Base.connection.instance_exec do
   ActiveRecord::Base.logger = Logger.new(STDOUT)
 
-  drop_table(:events, cascade: true) if Event.table_exists?
+  drop_table(:events, if_exists: true, cascade: true)
 
   hypertable_options = {
     time_column: 'created_at',

--- a/examples/all_in_one/benchmark_comparison.rb
+++ b/examples/all_in_one/benchmark_comparison.rb
@@ -34,8 +34,8 @@ end
 ActiveRecord::Base.connection.instance_exec do
   ActiveRecord::Base.logger = Logger.new(STDOUT)
 
-  drop_table(Event.table_name) if Event.table_exists?
-  drop_table(Event2.table_name) if Event2.table_exists?
+  drop_table(Event.table_name, if_exists: true)
+  drop_table(Event2.table_name, if_exists: true)
 
   hypertable_options = {
     time_column: 'created_at',

--- a/examples/all_in_one/caggs.rb
+++ b/examples/all_in_one/caggs.rb
@@ -29,7 +29,7 @@ class Tick < ActiveRecord::Base
 end
 
 ActiveRecord::Base.connection.instance_exec do
-  drop_table(:ticks, force: :cascade) if Tick.table_exists?
+  drop_table(:ticks, if_exists: true, force: :cascade)
 
   hypertable_options = {
     time_column: 'time',

--- a/examples/all_in_one/query_data.rb
+++ b/examples/all_in_one/query_data.rb
@@ -1,6 +1,6 @@
 require 'bundler/inline' #require only what you need
 
-gemfile(true) do 
+gemfile(true) do
   gem 'timescaledb', path:  '../..'
   gem 'pry'
   gem 'faker'
@@ -28,7 +28,7 @@ end
 ActiveRecord::Base.connection.instance_exec do
   ActiveRecord::Base.logger = Logger.new(STDOUT)
 
-  drop_table(Event.table_name) if Event.table_exists?
+  drop_table(Event.table_name, if_exists: true)
 
   hypertable_options = {
     time_column: 'created_at',

--- a/spec/timescaledb/migration_helper_spec.rb
+++ b/spec/timescaledb/migration_helper_spec.rb
@@ -3,9 +3,7 @@ RSpec.describe Timescaledb::MigrationHelpers, database_cleaner_strategy: :trunca
     let(:con) { ActiveRecord::Base.connection }
 
     before(:each) do
-      if con.table_exists?(:migration_tests)
-        con.drop_table :migration_tests, force: :cascade
-      end
+      con.drop_table :migration_tests, if_exists: true, force: :cascade
     end
 
     subject(:create_table) do
@@ -58,9 +56,7 @@ RSpec.describe Timescaledb::MigrationHelpers, database_cleaner_strategy: :trunca
     let(:con) { ActiveRecord::Base.connection }
 
     before(:each) do
-      if con.table_exists?(:ticks)
-        con.drop_table :ticks, force: :cascade
-      end
+      con.drop_table :ticks, if_exists: true, force: :cascade
       con.create_table :ticks, hypertable: hypertable_options, id: false do |t|
         t.string :symbol
         t.decimal :price

--- a/spec/timescaledb/schema_dumper_spec.rb
+++ b/spec/timescaledb/schema_dumper_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Timescaledb::SchemaDumper, database_cleaner_strategy: :truncation
 
     context "compress_segmentby" do
       before(:each) do
-        con.drop_table :segmentby_tests, force: :cascade if con.table_exists?(:segmentby_tests)
+        con.drop_table :segmentby_tests, if_exists: true, force: :cascade
       end
 
       it "handles multiple compress_segmentby" do
@@ -169,7 +169,7 @@ RSpec.describe Timescaledb::SchemaDumper, database_cleaner_strategy: :truncation
 
     context "compress_orderby" do
       before(:each) do
-        con.drop_table :orderby_tests, force: :cascade if con.table_exists?(:orderby_tests)
+        con.drop_table :orderby_tests, if_exists: true, force: :cascade
       end
 
       context "ascending order" do

--- a/spec/timescaledb/toolkit_helper_spec.rb
+++ b/spec/timescaledb/toolkit_helper_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Timescaledb::Toolkit::Helpers, database_cleaner_strategy: :trunca
       if con.table_exists?(:measurements)
         # We need to truncate to avoid foreign key constraint errors + deadlocks
         con.execute("TRUNCATE measurements CASCADE")
-        con.execute("DROP TABLE IF EXISTS measurements CASCADE")
+        con.execute("DROP TABLE measurements CASCADE")
       end
       con.create_table :measurements, hypertable: hypertable_options, id: false do |t|
         t.integer :device_id
@@ -197,7 +197,7 @@ SQL
       con.add_toolkit_to_search_path!
       if con.table_exists?(:measurements)
         con.execute("TRUNCATE measurements CASCADE")
-        con.execute("DROP TABLE IF EXISTS measurements CASCADE")
+        con.execute("DROP TABLE measurements CASCADE")
       end
       con.create_table :measurements, hypertable: hypertable_options, id: false do |t|
         t.integer :device_id
@@ -277,7 +277,7 @@ SQL
       con.add_toolkit_to_search_path!
       if con.table_exists?(:ticks)
         con.execute("TRUNCATE ticks CASCADE")
-        con.execute("DROP TABLE IF EXISTS ticks CASCADE")
+        con.execute("DROP TABLE ticks CASCADE")
       end
       con.create_table :ticks, hypertable: hypertable_options, id: false do |t|
         t.text :symbol


### PR DESCRIPTION
`drop_table t, if_exists: true` uses `DROP TABLE t IF EXISTS` making this check redundant.

https://github.com/rails/rails/blob/db4451e1c21623ce2cce742e08a36a1fbfd2978a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L59

https://github.com/rails/rails/blob/db4451e1c21623ce2cce742e08a36a1fbfd2978a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L543