### PR TITLE
Reorganize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # TimescaleDB
 
-A Ruby gem for working with TimescaleDB - an open-source time-series database built on PostgreSQL. This gem provides ActiveRecord integration and helpful tools for managing time-series data.
+> The Timescale SDK for Ruby
+
+A Ruby [gem](https://rubygems.org/gems/timescaledb) for working with TimescaleDB - an open-source time-series database built on PostgreSQL. This gem provides ActiveRecord integration and helpful tools for managing time-series data.
 
 ## What is TimescaleDB?
 
@@ -42,7 +44,7 @@ class CreateEvents < ActiveRecord::Migration[7.0]
       chunk_time_interval: '1 day',
       compress_segmentby: 'identifier',
       compress_after: '7 days',
-      compress_orderby: 'created_at DESC NULLS LAST',
+      compress_orderby: 'created_at DESC',
       drop_after: '3 months'
     }
 
@@ -126,6 +128,7 @@ create_table(:events, id: false, hypertable: hypertable_options) do |t|
   t.jsonb :payload
 end
 ```
+
 And the code above will create a hypertable with the following options:
 
 ```sql
@@ -146,11 +149,10 @@ SELECT add_retention_policy('events', INTERVAL '6 months');
 
 In this case, the hypertable will be created with the following options:
 
-* automatically partition - 1 table per day
-* compression enabled - 7 days after the first data
-* compression order - created_at DESC NULLS LAST
-* compression segmentby - identifier (this is the column that will be used to compress the data and also work as a hash key)
-* drop after - 6 months - This is a retention policy that will delete the data after 6 months.
+* [create hypertable](https://docs.timescale.com/api/latest/hypertable/create_hypertable/) for automatic partitioning - 1 table per day
+* [compression](https://docs.timescale.com/api/latest/compression/alter_table_compression/) enabled - partitions with data older than 7 days are compressed
+* [compression segmentby](https://docs.timescale.com/api/latest/compression/alter_table_compression/) configured - identifier (this is the column that will be used as a columnar storage key)
+* [drop after](https://docs.timescale.com/use-timescale/latest/data-retention/create-a-retention-policy/) configured - 6 months - This is a retention policy that will delete the old data after 6 months. Note this deletion is very efficient as it drops the entire partition.
 
 If you use keyword `compress_after` it will enable hypercore compression. Which can be used to set when the compression should start.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,450 @@
 # TimescaleDB
 
-Welcome to the TimescaleDB gem! To experiment with the code, start installing the
-gem:
+A Ruby gem for working with TimescaleDB - an open-source time-series database built on PostgreSQL. This gem provides ActiveRecord integration and helpful tools for managing time-series data.
+
+## What is TimescaleDB?
+
+TimescaleDB extends PostgreSQL with specialized features for time-series data:
+
+- **Hypertables**: Automatically partitioned tables optimized for time-series data
+- **Hypercores**: Hypercore is a dynamic storage engine that allows you to store data in a way that is optimized for time-series data. Mixing columnar and row-based storage.
+- **Chunks**: Transparent table partitions that improve query performance
+- **Continuous Aggregates**: Materialized views that automatically update
+- **Data Compression**: Automatic compression of older data
+- **Data Retention**: Policies for managing data lifecycle
+
+## Installation
+
+Add to your Gemfile:
+
+```ruby
+gem 'timescaledb'
+```
+
+Or install directly:
 
 ```bash
 gem install timescaledb
+```
+
+## Quick Start
+
+### 1. Enable TimescaleDB in Your Models
+
+```ruby
+# config/initializers/timescaledb.rb
+ActiveSupport.on_load(:active_record) { extend Timescaledb::ActsAsHypertable }
+
+# app/models/event.rb
+class Event < ActiveRecord::Base
+  acts_as_hypertable
+end
+```
+
+### 2. Create Hypertables in Migrations
+
+```ruby
+hypertable_options = {
+  time_column: 'created_at',
+  chunk_time_interval: '1 min',
+  compress_segmentby: 'identifier',
+  compress_after: '7 days',
+  compress_orderby: 'created_at DESC NULLS LAST',
+  drop_after: '6 months'
+}
+
+create_table(:events, id: false, hypertable: hypertable_options) do |t|
+  t.string :identifier, null: false
+  t.jsonb :payload
+  t.timestamps
+end
+```
+
+## Usage
+
+Check the [examples/ranking](examples/ranking) to get a Rails complete example.
+
+You can check the [all_in_one.rb](examples/all_in_one/all_in_one.rb) example that will:
+
+1. Create hypertable with compression settings
+2. Insert data
+3. Run some queries
+4. Check chunk size per model
+5. Compress a chunk
+6. Check chunk status
+7. Decompress a chunk
+
+### The Timescaledb Toolkit
+
+The Timescaledb Toolkit is an extension that contains a lot of extra features to analyse data more deeply directly in
+the SQL. There are a few examples in the [examples/toolkit-demo](examples/toolkit-demo) folder that can let you benchmark and see the differences between implementing the algorithm directly in Ruby or directly in SQL using the [Timescaledb Toolkit](https://github.com/timescale/timescaledb-toolkit) extension.
+
+For now you can benchmark and compare:
+
+1. [volatility](examples/toolkit-demo/compare_volatility.rb) algorithm.
+2. [lttb](examples/toolkit-demo/lttb/lttb_sinatra.rb) algorithm.
+
+You can also watch this talk from RubyConf Thailand which covers the toolkit: [Ruby or SQL? where to process your data](https://www.youtube.com/watch?v=MXAtSZ5Szgk).
+
+
+### Testing
+
+If you need some inspiration for how are you going to test your hypertables,
+please check the [spec/spec_helper.rb](spec/spec_helper.rb) for inspiration.
+
+### Migrations
+
+Create table is now with the `hypertable` keyword allowing to pass a few options
+to the function call while also using `create_table` method:
+
+#### create_table with `:hypertable`
+
+You can just pass the options to the `hypertable` keyword:
+
+```ruby
+hypertable_options = {
+  time_column: 'created_at',
+  chunk_time_interval: '1 day',
+  compress_segmentby: 'identifier',
+  compress_after: '7 days',
+  compress_orderby: 'created_at DESC NULLS LAST',
+  drop_after: '6 months'
+}
+
+create_table(:events, id: false, hypertable: hypertable_options) do |t|
+  t.string :identifier, null: false
+  t.jsonb :payload
+  t.timestamps
+end
+```
+
+And the code above will create a hypertable with the following options:
+
+```sql
+CREATE TABLE events (
+  identifier text NOT NULL,
+  payload jsonb,
+  created_at timestamp with time zone NOT NULL,
+  updated_at timestamp with time zone NOT NULL
+)
+SELECT create_hypertable('events', by_range('created_at', INTERVAL '1 day'));
+ALTER TABLE events SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'identifier',
+  timescaledb.compress_orderby = 'created_at DESC NULLS LAST'
+);
+SELECT add_compression_policy('events', INTERVAL '7 days');
+SELECT add_retention_policy('events', INTERVAL '6 months');
+```
+
+#### create_continuous_aggregate
+
+This example shows a ticks table grouping ticks as OHLCV histograms for every
+minute.
+
+```ruby
+class CreateTicks < ActiveRecord::Migration[7.0]
+  def up
+    hypertable_options = {
+      time_column: 'created_at',
+      chunk_time_interval: '1 day',
+      compress_segmentby: 'symbol',
+      compress_orderby: 'created_at',
+      compress_after: '30 days'
+    }
+    create_table :ticks, hypertable: hypertable_options, id: false do |t|
+      t.string :symbol
+      t.decimal :price
+      t.integer :volume
+      t.timestamps
+    end
+    create_continuous_aggregate_ohlc_1m
+  end
+
+  def down
+    drop_table :ticks
+    drop_continuous_aggregate :ohlc_1m
+  end
+
+  private
+
+  def create_continuous_aggregate_ohlc_1m
+    query = Tick.select(<<~QUERY)
+      time_bucket('1 day', created_at) as time,
+      symbol,
+      FIRST(price, created_at) as open,
+      MAX(price) as high,
+      MIN(price) as low,
+        LAST(price, created_at) as close,
+        SUM(volume) as volume").group("1,2")
+      QUERY
+
+      options = {
+        with_data: false,
+        refresh_policies: {
+          start_offset: "INTERVAL '1 month'",
+          end_offset: "INTERVAL '1 minute'",
+          schedule_interval: "INTERVAL '1 minute'"
+        }
+      }
+
+    create_continuous_aggregate('ohlc_1m', query, **options)
+  end
+end
+```
+
+Alternatively, you can use the `continuous_aggregate` macro in the model to rollup hierarchically several timeframes:
+
+```ruby
+class Tick < ActiveRecord::Base
+  extend Timescaledb::ActsAsHypertable
+  include Timescaledb::ContinuousAggregatesHelper
+
+  self.table_name = 'crypto_ticks'
+
+  acts_as_hypertable time_column: 'time',
+    segment_by: 'symbol',
+    value_column: 'price'
+
+  scope :btc, -> { where(symbol: 'BTC/USD') }
+  scope :ohlc, lambda {
+    _candlestick(volume: :day_volume)
+  }
+
+  continuous_aggregates(
+    timeframes: %i[minute hour day month],
+    scopes: [:ohlc]
+  )
+end
+```
+And then in the migration you can create the continuous aggregates:
+
+```ruby
+class CreateContinuousAggregates < ActiveRecord::Migration[7.0]
+  def up
+    Tick.create_continuous_aggregates
+  end
+
+  def down
+    Tick.drop_continuous_aggregates
+  end
+end
+```
+
+It will create the continuous aggregates for the given timeframes and scopes and create nested classes for each timeframe.
+
+Check the [blog post](https://www.timescale.com/blog/building-a-better-ruby-orm-for-time-series-and-analytics) for more details.
+
+#### Scenic integration
+
+The [Scenic](https://github.com/scenic-views/scenic) gem is an easy way to
+manage database view definitions for a Rails application. TimescaleDB's
+continuous aggregates are more complex than regular PostgreSQL views, and
+the schema dumper included with Scenic can't dump a complete definition.
+
+This gem automatically configures Scenic to use a `Timescaledb::Scenic::Adapter`
+which will correctly handle schema dumping.
+
+### Enable ActsAsHypertable
+
+Create your `config/initializers/timescaledb.rb` file and add the following line:
+
+```ruby
+ActiveSupport.on_load(:active_record) { extend Timescaledb::ActsAsHypertable }
+```
+
+You can declare a Rails model as a Hypertable by invoking the `acts_as_hypertable` macro. This macro extends your existing model with timescaledb-related functionality.
+model:
+
+```ruby
+class Event < ActiveRecord::Base
+  acts_as_hypertable
+end
+```
+
+By default, ActsAsHypertable assumes a record's _time_column_ is called `created_at`.
+
+You may isolate your hypertables in another database, so, creating an abstract
+layer for your hypertables is a good idea:
+
+```ruby
+class Hypertable < ActiveRecord::Base
+  self.abstract_class = true
+
+  extend Timescaledb::ActsAsHypertable
+
+  establish_connection :timescaledb
+end
+```
+
+And then, you can inherit from this model:
+
+```ruby
+class Event < Hypertable
+  acts_as_hypertable time_column: "time"
+end
+```
+
+Or you can include only when you're going to use them:
+
+```ruby
+class Event < ActiveRecord::Base
+  extend Timescaledb::ActsAsHypertable
+
+  establish_connection :timescaledb
+
+  acts_as_hypertable time_column: "time"
+end
+```
+
+### Options
+
+If you are using a different time_column name, you can specify it as follows when invoking the `acts_as_hypertable` macro:
+
+```ruby
+class Event < ActiveRecord::Base
+  acts_as_hypertable time_column: :timestamp
+end
+```
+
+### Chunks
+
+To get all the chunks from a model's hypertable, you can use `.chunks`.
+
+```ruby
+Event.chunks # => [#<Timescaledb::Chunk>, ...]
+```
+
+### Hypertable metadata
+
+To get the models' hypertable metadata, you can use `.hypertable`.
+
+```ruby
+Event.hypertable # => #<Timescaledb::Hypertable>
+```
+
+To get hypertable metadata for all hypertables: `Timescaledb.hypertables`.
+
+### Compression Settings
+
+Compression settings are accessible through the hypertable.
+
+```ruby
+Event.hypertable.compression_settings # => [#<Timescaledb::CompressionSettings>, ...]
+```
+
+To get compression settings for all hypertables: `Timescaledb.compression_settings`.
+
+### Skip association scopes
+
+If you don't want to overload your model, you can skip the `.hypertable` and other association scopes by passing `skip_association_scopes: true` to the `acts_as_hypertable` macro.
+
+```ruby
+class Event < ActiveRecord::Base
+  acts_as_hypertable time_column: "time", skip_association_scopes: true
+end
+```
+
+### Scopes
+
+The `acts_as_hypertable` macro can be very useful to generate some extra scopes
+for you. Example of a weather condition:
+
+```ruby
+class Condition < ActiveRecord::Base
+  acts_as_hypertable time_column: "time"
+end
+```
+
+Through the [ActsAsHypertable](./lib/timescaledb/acts_as_hypertable) on the model,
+a few scopes are created based on the `time_column` argument:
+
+| Scope name             | What they return                      |
+|------------------------|---------------------------------------|
+| `Model.previous_month` | Records created in the previous month |
+| `Model.previous_week`  | Records created in the previous week  |
+| `Model.this_month`     | Records created this month            |
+| `Model.this_week`      | Records created this week             |
+| `Model.yesterday`      | Records created yesterday             |
+| `Model.today`          | Records created today                 |
+| `Model.last_hour`      | Records created in the last hour      |
+
+All time-related scopes respect your application's timezone.
+
+When you enable ActsAsTimeVector on your model, we include a couple default scopes. They are:
+
+```ruby
+class Condition < ActiveRecord::Base
+  acts_as_hypertable time_column: "time",
+    value_column: "temperature",
+    segment_by: "device_id"
+end
+```
+
+### Skip default scopes
+
+You can skip the default scopes by passing `skip_default_scopes: true` to the `acts_as_hypertable` macro.
+
+```ruby
+class Condition < ActiveRecord::Base
+  acts_as_hypertable time_column: "time", skip_default_scopes: true
+end
+```
+
+You can also use `skip_time_vector` to skip the time vector related scopes.
+Or you can use `skip_association_scopes` to skip the association scopes.
+
+## Schema Dumper
+
+If you're using the gem with Rails and you want to dump the schema to a file,
+The schema dumper will include:
+
+* hypertables configuration
+* compression settings
+* continuous aggregates (also integrated with Scenic gem)
+* compression and retention policies
+
+The idea is try to mimic the last state of art of the database.
+The schema dumper will also ignore the `Timescaledb::SchemaDumper::IGNORE_SCHEMAS`
+that is an array of schema names that you want to ignore. By default it ignores
+all catalog and metadata generated by the extension, but keep in mind you can
+change this behavior.
+
+```ruby
+Timescaledb::SchemaDumper::IGNORE_SCHEMAS << "ignore_my_schema_too"
+```
+
+Note that the schema dumper only provides output for the ruby version of the schema. If you use sql schema, you will need to create the hypertables manually as described in the [RSpec Hooks](#rspec-hooks) section.
+
+## RSpec Hooks
+
+In case you want to use TimescaleDB on a Rails environment, you may have some
+issues as the schema dump used for tests does not consider hypertables metadata.
+
+As a work around, you can dynamically create the hypertables yourself for
+testing environments using the following hook which you can
+define in `spec/rspec_helper.rb`:
+
+
+```ruby
+config.before(:suite) do
+
+  hypertable_models = ActiveRecord::Base.descendants.select(&:acts_as_hypertable?)
+
+  hypertable_models.each do |klass|
+    table_name = klass.table_name
+    time_column = klass.hypertable_options[:time_column]
+
+    if klass.try(:hypertable).present?
+      ApplicationRecord.logger.info "hypertable already created for '#{table_name}', skipping."
+      next
+    end
+
+    ApplicationRecord.connection.instance_exec(table_name, time_column) do |table_name, time_column|
+      create_hypertable(table_name, by_range(time_column.to_s, INTERVAL '1 day'))
+    end
+  end
+end
 ```
 
 ## The `tsdb` CLI
@@ -24,7 +464,6 @@ Where the `<uri>` is replaced with params from your connection like:
 ```bash
 tsdb postgres://<user>@localhost:5432/<dbname> --stats
 ```
-
 
 Or just check the stats:
 
@@ -189,357 +628,6 @@ Ohlc1m.order(bucket: :desc).last
  volume: 27600>
 ```
 
-## Installation
-
-Add this line to your application's Gemfile:
-
-```ruby
-gem 'timescaledb'
-```
-
-And then execute:
-
-    $ bundle install
-
-Or install it yourself as:
-
-    $ gem install timescaledb
-
-
-## Usage
-
-Check the [examples/ranking](examples/ranking) to get a Rails complete example.
-
-You can check the [all_in_one.rb](examples/all_in_one/all_in_one.rb) example that will:
-
-1. Create hypertable with compression settings
-2. Insert data
-3. Run some queries
-4. Check chunk size per model
-5. Compress a chunk
-6. Check chunk status
-7. Decompress a chunk
-
-### Toolkit
-
-Toolkit contains a lot of extra features to analyse data more deeply directly in
-the SQL. There are a few examples in the [examples/toolkit-demo](examples/toolkit-demo)
-folder that can let you benchmark and see the differences between implementing
-the algorithm directly in Ruby or directly in SQL using the [Timescaledb
-Toolkit](https://github.com/timescale/timescaledb-toolkit) extension.
-
-For now you can benchmark and compare:
-
-1. [volatility](examples/toolkit-demo/compare_volatility.rb) algorithm.
-2. [lttb](examples/toolkit-demo/lttb/lttb_sinatra.rb) algorithm.
-
-### Testing
-
-If you need some inspiration for how are you going to test your hypertables,
-please check the [spec/spec_helper.rb](spec/spec_helper.rb) for inspiration.
-
-### Migrations
-
-Create table is now with the `hypertable` keyword allowing to pass a few options
-to the function call while also using `create_table` method:
-
-#### create_table with `:hypertable`
-
-You can just pass the options to the `hypertable` keyword:
-
-```ruby
-hypertable_options = {
-  time_column: 'created_at',
-  chunk_time_interval: '1 min',
-  compress_segmentby: 'identifier',
-  compress_after: '7 days',
-  compress_orderby: 'created_at DESC NULLS LAST',
-  drop_after: '6 months'
-}
-
-create_table(:events, id: false, hypertable: hypertable_options) do |t|
-  t.string :identifier, null: false
-  t.jsonb :payload
-  t.timestamps
-end
-```
-
-And the code above will create a hypertable with the following options:
-
-```sql
-CREATE TABLE events (
-  identifier text NOT NULL,
-  payload jsonb,
-  created_at timestamp with time zone NOT NULL,
-  updated_at timestamp with time zone NOT NULL
-)
-SELECT create_hypertable('events', by_range('created_at', INTERVAL '1 min');
-ALTER TABLE events SET (
-  timescaledb.compress,
-  timescaledb.compress_segmentby = 'identifier',
-  timescaledb.compress_orderby = 'created_at DESC NULLS LAST',
-  timescaledb.drop_after = INTERVAL '6 months'
-);
-
-SELECT add_compression_policy('events', INTERVAL '7 days');
-SELECT add_retention_policy('events', INTERVAL '6 months');
-```
-
-#### create_continuous_aggregate
-
-This example shows a ticks table grouping ticks as OHLCV histograms for every
-minute.
-
-```ruby
-hypertable_options = {
-  time_column: 'created_at',
-  chunk_time_interval: '1 min',
-  compress_segmentby: 'symbol',
-  compress_orderby: 'created_at',
-  compress_after: '7 days'
-}
-create_table :ticks, hypertable: hypertable_options, id: false do |t|
-  t.string :symbol
-  t.decimal :price
-  t.integer :volume
-  t.timestamps
-end
-Tick = Class.new(ActiveRecord::Base) do
-  self.table_name = 'ticks'
-  self.primary_key = 'symbol'
-  acts_as_hypertable
-end
-
-query = Tick.select(<<~QUERY)
-  time_bucket('1m', created_at) as time,
-  symbol,
-  FIRST(price, created_at) as open,
-  MAX(price) as high,
-  MIN(price) as low,
-  LAST(price, created_at) as close,
-  SUM(volume) as volume").group("1,2")
-QUERY
-
-options = {
-  with_data: false,
-  refresh_policies: {
-    start_offset: "INTERVAL '1 month'",
-    end_offset: "INTERVAL '1 minute'",
-    schedule_interval: "INTERVAL '1 minute'"
-  }
-}
-
-create_continuous_aggregate('ohlc_1m', query, **options)
-```
-
-#### Scenic integration
-
-The [Scenic](https://github.com/scenic-views/scenic) gem is an easy way to
-manage database view definitions for a Rails application. TimescaleDB's
-continuous aggregates are more complex than regular PostgreSQL views, and
-the schema dumper included with Scenic can't dump a complete definition.
-
-This gem automatically configures Scenic to use a `Timescaledb::Scenic::Adapter`
-which will correctly handle schema dumping.
-
-### Enable ActsAsHypertable
-
-Create your `config/initializers/timescaledb.rb` file and add the following line:
-
-```ruby
-ActiveSupport.on_load(:active_record) { extend Timescaledb::ActsAsHypertable }
-```
-
-You can declare a Rails model as a Hypertable by invoking the `acts_as_hypertable` macro. This macro extends your existing model with timescaledb-related functionality.
-model:
-
-```ruby
-class Event < ActiveRecord::Base
-  acts_as_hypertable
-end
-```
-
-By default, ActsAsHypertable assumes a record's _time_column_ is called `created_at`.
-
-You may isolate your hypertables in another database, so, creating an abstract
-layer for your hypertables is a good idea:
-
-```ruby
-class Hypertable < ActiveRecord::Base
-  self.abstract_class = true
-
-  extend Timescaledb::ActsAsHypertable
-
-  establish_connection :timescaledb
-end
-```
-
-And then, you can inherit from this model:
-
-```ruby
-class Event < Hypertable
-  acts_as_hypertable time_column: "time"
-end
-```
-
-Or you can include only when you're going to use them:
-
-```ruby
-class Event < ActiveRecord::Base
-  extend Timescaledb::ActsAsHypertable
-
-  establish_connection :timescaledb
-
-  acts_as_hypertable time_column: "time"
-end
-```
-
-### Options
-
-If you are using a different time_column name, you can specify it as follows when invoking the `acts_as_hypertable` macro:
-
-```ruby
-class Event < ActiveRecord::Base
-  acts_as_hypertable time_column: :timestamp
-end
-```
-
-### Chunks
-
-To get all the chunks from a model's hypertable, you can use `.chunks`.
-
-```ruby
-Event.chunks # => [#<Timescaledb::Chunk>, ...]
-```
-
-### Hypertable metadata
-
-To get the models' hypertable metadata, you can use `.hypertable`.
-
-```ruby
-Event.hypertable # => #<Timescaledb::Hypertable>
-```
-
-To get hypertable metadata for all hypertables: `Timescaledb.hypertables`.
-
-### Compression Settings
-
-Compression settings are accessible through the hypertable.
-
-```ruby
-Event.hypertable.compression_settings # => [#<Timescaledb::CompressionSettings>, ...]
-```
-
-To get compression settings for all hypertables: `Timescaledb.compression_settings`.
-
-### Skip association scopes
-
-If you don't want to overload your model, you can skip the `.hypertable` and other association scopes by passing `skip_association_scopes: true` to the `acts_as_hypertable` macro.
-
-```ruby
-class Event < ActiveRecord::Base
-  acts_as_hypertable time_column: "time", skip_association_scopes: true
-end
-```
-
-### Scopes
-
-The `acts_as_hypertable` macro can be very useful to generate some extra scopes
-for you. Example of a weather condition:
-
-```ruby
-class Condition < ActiveRecord::Base
-  acts_as_hypertable time_column: "time"
-end
-```
-
-Through the [ActsAsHypertable](./lib/timescaledb/acts_as_hypertable) on the model,
-a few scopes are created based on the `time_column` argument:
-
-| Scope name             | What they return                      |
-|------------------------|---------------------------------------|
-| `Model.previous_month` | Records created in the previous month |
-| `Model.previous_week`  | Records created in the previous week  |
-| `Model.this_month`     | Records created this month            |
-| `Model.this_week`      | Records created this week             |
-| `Model.yesterday`      | Records created yesterday             |
-| `Model.today`          | Records created today                 |
-| `Model.last_hour`      | Records created in the last hour      |
-
-All time-related scopes respect your application's timezone.
-
-When you enable ActsAsTimeVector on your model, we include a couple default scopes. They are:
-
-```ruby
-class Condition < ActiveRecord::Base
-  acts_as_hypertable time_column: "time",
-    value_column: "temperature",
-    segment_by: "device_id"
-end
-```
-
-### Skip default scopes
-
-You can skip the default scopes by passing `skip_default_scopes: true` to the `acts_as_hypertable` macro.
-
-```ruby
-class Condition < ActiveRecord::Base
-  acts_as_hypertable time_column: "time", skip_default_scopes: true
-end
-```
-
-You can also use `skip_time_vector` to skip the time vector related scopes.
-Or you can use `skip_association_scopes` to skip the association scopes.
-
-## RSpec Hooks
-
-In case you want to use TimescaleDB on a Rails environment, you may have some
-issues as the schema dump used for tests does not consider hypertables metadata.
-
-As a work around, you can dynamically create the hypertables yourself for
-testing environments using the following hook which you can
-define in `spec/rspec_helper.rb`:
-
-```ruby
-config.before(:suite) do
-
-  hypertable_models = ActiveRecord::Base.descendants.select(&:acts_as_hypertable?)
-
-  hypertable_models.each do |klass|
-    table_name = klass.table_name
-    time_column = klass.hypertable_options[:time_column]
-
-    if klass.try(:hypertable).present?
-      ApplicationRecord.logger.info "hypertable already created for '#{table_name}', skipping."
-      next
-    end
-
-    ApplicationRecord.connection.execute <<~SQL
-      SELECT create_hypertable('#{table_name}', '#{time_column.to_s}')
-    SQL
-  end
-end
-```
-
-## Schema Dumper
-
-If you're using the gem with Rails and you want to dump the schema to a file,
-The schema dumper will include:
-
-* hypertables configuration
-* compression settings
-* continuous aggregates (also integrated with Scenic gem)
-* compression and retention policies
-
-The idea is try to mimic the last state of art of the database.
-The schema dumper will also ignore the `Timescaledb::SchemaDumper::IGNORE_SCHEMAS`
-that is an array of schema names that you want to ignore. By default it ignores
-all catalog and metadata generated by the extension, but keep in mind you can
-change this behavior.
-
-```ruby
-Timescaledb::SchemaDumper::IGNORE_SCHEMAS << "ignore_my_schema_too"
-```
 
 ## Development
 

--- a/examples/all_in_one/all_in_one.rb
+++ b/examples/all_in_one/all_in_one.rb
@@ -14,28 +14,57 @@ ActiveRecord::Base.establish_connection( ARGV.last)
 
 # Simple example
 class Event < ActiveRecord::Base
-  self.primary_key = nil
-  acts_as_hypertable
+  extend Timescaledb::ActsAsHypertable
+  include Timescaledb::ContinuousAggregatesHelper
+
+  acts_as_hypertable time_column: "time",
+    segment_by: "identifier"
+
+  scope :count_clicks, -> { select("count(*)").where(identifier: "click") }
+  scope :count_views, -> { select("count(*)").where(identifier: "views") }
+
+  continuous_aggregates scopes: [:count_clicks, :count_views],
+    timeframes: [:minute, :hour, :day],
+    refresh_policy: {
+      minute: {
+        start_offset: '3 minute',
+        end_offset: '1 minute',
+        schedule_interval: '1 minute'
+      },
+      hour: {
+        start_offset: '3 hours',
+        end_offset: '1 hour',
+        schedule_interval: '1 minute'
+      },
+      day: {
+        start_offset: '3 day',
+        end_offset: '1 day',
+        schedule_interval: '1 minute'
+      }
+    }
 end
 
 # Setup Hypertable as in a migration
 ActiveRecord::Base.connection.instance_exec do
   ActiveRecord::Base.logger = Logger.new(STDOUT)
 
+  Event.drop_continuous_aggregates
   drop_table(:events, if_exists: true, cascade: true)
 
   hypertable_options = {
-    time_column: 'created_at',
+    time_column: 'time',
     chunk_time_interval: '1 day',
     compress_segmentby: 'identifier',
+    compress_orderby: 'time',
     compress_after: '7 days'
   }
 
   create_table(:events, id: false, hypertable: hypertable_options) do |t|
+    t.timestamptz :time, null: false, default: -> { 'now()' }
     t.string :identifier, null: false
     t.jsonb :payload
-    t.timestamps
   end
+  Event.create_continuous_aggregates
 end
 
 # Create some data just to see how it works
@@ -56,8 +85,7 @@ def generate_fake_data(total: 100_000)
     identifier = %w[sign_up login click scroll logout view]
     time = time + rand(60).seconds
     {
-      created_at: time,
-      updated_at: time,
+      time: time,
       identifier: identifier.sample,
       payload: {
         "name" => Faker::Name.name,
@@ -79,8 +107,11 @@ supress_logs do
 end
 # Now let's see what we have in the scopes
 Event.last_hour.group(:identifier).count # => {"login"=>2, "click"=>1, "logout"=>1, "sign_up"=>1, "scroll"=>1}
+Event.refresh_aggregates
+pp Event::CountClicksPerMinute.last_hour.map(&:attributes)
+pp Event::CountViewsPerMinute.last_hour.map(&:attributes)
 
-puts "compressing #{ Event.chunks.count }"
+puts "compressing 1 chunk of #{ Event.chunks.count } chunks"
 Event.chunks.first.compress!
 
 puts "detailed size"

--- a/lib/timescaledb/acts_as_hypertable.rb
+++ b/lib/timescaledb/acts_as_hypertable.rb
@@ -23,7 +23,6 @@ module Timescaledb
   module ActsAsHypertable
     DEFAULT_OPTIONS = {
       time_column: :created_at,
-      # Add any default time vector options here if needed
     }.freeze
 
     def acts_as_hypertable?


### PR DESCRIPTION
I tried to bring a smooth experience to the readme as I piled content there for years.

1. Introduce concepts from Timescale and present the DSL.
2. Remove repeated docs like the command line parts.
3. Remove examples using other model names. Keep only `Event` as the core hypertable example.
