### PR TITLE
Delete .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
----
-language: ruby
-cache: bundler
-rvm:
-  - 3.1.2
-before_install: gem install bundler
-gemfile:
-  - Gemfile
-  - Gemfile.scenic


### PR DESCRIPTION
PR removes the `.travis.yml` configuration file as the repo doesn't use Travis-CI, and I cannot envision a world where that'd happen.