### PR TITLE
Update gemika to use gh actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,9 +57,7 @@ jobs:
         echo "SELECT version()" | psql -h database -U username testdb
         echo "SELECT CURRENT_TIME" | psql -h database -U username testdb
 
-    - name: Setup
-      run: |
-        ./bin/setup
+    - run: bundle install
 
     - name: run tsdb
       run: ./bin/tsdb postgres://username:secret@database:5432/testdb --stats

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
 
     runs-on: ubuntu-latest
-    name: OS Ruby ${{matrix.ruby}} database ${{matrix.database}}
+    name: OS Ruby ${{matrix.ruby}} (${{matrix.gemfile}}) database ${{matrix.database}}
     container: ruby:${{matrix.ruby}}
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ '3.1.2' ]
+        gemfile: [ 'Gemfile', 'Gemfile.scenic' ]
         database:
           - 'pg17-ts2.17-all'
           - 'pg16-ts2.17-all'
           - 'pg15-ts2.17-all'
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
 
     services:
       database:
@@ -68,5 +71,5 @@ jobs:
         bundle exec rake test:setup
 
     - name: Test
-      run: bundle exec rake
+      run: bundle exec rake spec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
----
-language: ruby
-cache: bundler
-rvm:
-  - 3.1.2
-before_install: gem install bundler
-gemfile:
-  - Gemfile
-  - Gemfile.scenic


### PR DESCRIPTION
Follow-up PR to #96 which migrates `gemika` to use the GH action file instead of the `.travis.yml` file. The caveat here of this functioning is that:

1. The GH workflow must be named `test.yml`
2. You must define your ruby versions in the `matrix.ruby` key and your gemfiles in `matrix.gemfile` (or under `matrix.include` entries
3. As this relies on the matrix definition, it's letting GH handle the matrix generation so you'll have a job per entry and as such you don't want to use `gemika` (via `matrix:spec`) to run the suite, instead directly using rspec, with setting gemfile bundler looks at via `BUNDLE_GEMFILE` environment variable.