### PR TITLE
Fix links to jonatas.github.io/timescaledb

### DIFF
--- a/docs/toolkit_lttb_tutorial.md
+++ b/docs/toolkit_lttb_tutorial.md
@@ -164,7 +164,7 @@ If you want to understand the algorithm behind the scenes, this step will make i
 
     The obvious answer is to use a brute-force approach and simply try out all the possibilities. That is, for each point in the current bucket, form a triangle with all the points in the next bucket. It turns out that this gives a fairly good visual result, but as with many brute-force approaches it is inefficient. For example, if there were 100 points per bucket, the algorithm would need to calculate the area of 10,000 triangles for every bucket. Another and more clever solution is to add a temporary point to the last bucket and keep it fixed. That way the algorithm has two fixed points; and one only needs to calculate the number of triangles equal to the number of points in the current bucket. The point in the current bucket which forms the largest triangle with this two fixed point in the adjacent buckets is then selected. In figure 4.4 it is shown how point B forms the largest triangle across the buckets with fixed point A (previously selected) and the temporary point C.
 
-    ![LTTB Triangle Bucketing Example](https://jonatas.github.io/timescaledb/img/lttb_example.png)
+    ![LTTB Triangle Bucketing Example](img/lttb_example.png)
 
 ### Calculate the area of a Triangle
 
@@ -485,7 +485,7 @@ end
 Now that both endpoints are ready, it's easy to check the results and
 understand how fast Ruby can execute each solution.
 
-![LTTB in action](https://jonatas.github.io/timescaledb/img/lttb_sql_vs_ruby.gif)
+![LTTB in action](img/lttb_sql_vs_ruby.gif)
 
 In the logs, we can see the time difference between every result:
 

--- a/docs/toolkit_lttb_zoom.md
+++ b/docs/toolkit_lttb_zoom.md
@@ -23,7 +23,7 @@ In this example, we're going to use the [lttb][3] function, that is  part of the
  The image bellow corresponds to the step by step guide provided here.
 
 
-![LTTB Zoomable Example](https://jonatas.github.io/timescaledb/img/lttb_zoom.gif)
+![LTTB Zoomable Example](img/lttb_zoom.gif)
 
 
 If you want to just go and run it directly, you can fetch the complete example [here][2].

--- a/examples/toolkit-demo/candlestick.rb
+++ b/examples/toolkit-demo/candlestick.rb
@@ -1,5 +1,5 @@
 # ruby candlestick.rb postgres://user:pass@host:port/db_name
-# @see https://jonatas.github.io/timescaledb/candlestick_tutorial
+# @see https://timescale.github.io/timescaledb-ruby/toolkit_candlestick/
 
 require 'bundler/inline' #require only what you need
 

--- a/examples/toolkit-demo/lttb-zoom/README.md
+++ b/examples/toolkit-demo/lttb-zoom/README.md
@@ -8,6 +8,6 @@ There is a [./lttb_zoomable.rb](./lttb_zoomable.rb) file is a small webserver th
 the SQL vs Ruby implementation. It also uses the [./views](./views) folder which
 contains the view with the rendering and javascript part.
 
-You can learn more by reading the [LTTB Zoom tutorial](https://jonatas.github.io/timescaledb/toolkit_lttb_zoom/).
+You can learn more by reading the [LTTB Zoom tutorial](https://timescale.github.io/timescaledb-ruby/toolkit_lttb_zoom/).
 
 

--- a/examples/toolkit-demo/lttb/README.md
+++ b/examples/toolkit-demo/lttb/README.md
@@ -10,6 +10,6 @@ The [./lttb_sinatra.rb](./lttb_sinatra.rb) is a small webserver that compares
 the SQL vs Ruby implementation. It also uses the [./views](./views) folder which
 contains the view rendering part.
 
-You can learn more by reading the [LTTB tutorial](https://jonatas.github.io/timescaledb/toolkit_lttb_tutorial/).
+You can learn more by reading the [LTTB tutorial](https://timescale.github.io/timescaledb-ruby/toolkit_lttb_tutorial/).
 
 


### PR DESCRIPTION
PR fixes a couple of links I found to `jonatas.github.io/timescaledb` to work with the new repo location. For the three images, I chose to use relative paths as `mkdocs` seemed to be fine with it locally, and this seemed less brittle in case the repo ever changed names again.