### PR TITLE
fix interval to drop_after

### DIFF
--- a/lib/timescaledb/schema_dumper.rb
+++ b/lib/timescaledb/schema_dumper.rb
@@ -90,7 +90,7 @@ module Timescaledb
 
     def timescale_retention_policy(hypertable, stream)
       hypertable.jobs.where(proc_name: "policy_retention").each do |job|
-        stream.puts %Q[  create_retention_policy "#{job.hypertable_name}", interval: "#{job.config["drop_after"]}"]
+        stream.puts %Q[  create_retention_policy "#{job.hypertable_name}", drop_after: "#{job.config["drop_after"]}"]
       end
     end
 

--- a/spec/timescaledb/schema_dumper_spec.rb
+++ b/spec/timescaledb/schema_dumper_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Timescaledb::SchemaDumper, database_cleaner_strategy: :truncation
       it "add retention policies after hypertables" do
         dump = dump_output
         last_hypertable = dump.index(%|create_hypertable "#{sorted_hypertables.last}"|)
-        index = dump.index(%|create_retention_policy "events", interval: "P7D"|)
+        index = dump.index(%|create_retention_policy "events", drop_after: "P7D"|)
         expect(index).to be > last_hypertable
       end
     end


### PR DESCRIPTION
Similar to #83, there is an `ArgumentError: missing keyword: :drop_after` thrown when attempting to load from `schema.rb` due to an invalid argument name of `interval`.